### PR TITLE
Add basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To run under HTTPS on your own machine:
     STREAMLIT_BROWSER_SERVER_ADDRESS=secure.localhost docker-compose up -d
     ```
 
-5. Visit https://secure.localhost:8081/
+5. Visit https://secure.localhost:8502/
 
 # Streamlit reverse proxy issues
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,52 @@ To run under HTTPS on your own machine:
 
 5. Visit https://secure.localhost:8502/
 
+The site uses HTTP basic auth, which is implemented not in Streamlit but in the [Nginx reverse proxy server](http://nginx.org/en/docs/http/ngx_http_auth_basic_module.html). Log in with these details:
+
+username: `demouser`
+password: `p4s5w0rd`
+
+Once logged in, your credentials persist until you restart your browser (or the Nginx server).
+
+You can use the same credentials to authenticate programmatic calls (e.g. API calls), but using the `Authorization` HTTP header, with this format:
+
+```
+Authorization: Basic <token>
+```
+
+Where `<token>` is formed by concatenating the username and password with a colon and then base64-encoding the result.
+
+GET without authentication returns a 401 error:
+
+```sh
+$ curl -I https://secure.localhost:8502
+HTTP/1.1 401 Unauthorized
+Server: nginx/1.21.5
+Date: Mon, 07 Feb 2022 11:49:22 GMT
+Content-Type: text/html
+Content-Length: 179
+Connection: keep-alive
+WWW-Authenticate: Basic realm="Top Secret Site"
+```
+
+GET with authentication returns a 200 result:
+
+```sh
+$ export TOKEN=$(echo -n "demouser:p4s5w0rd" | base64)
+$ curl -I -H "Authorization: Basic $TOKEN" https://secure.localhost:8502
+HTTP/1.1 200 OK
+Server: nginx/1.21.5
+Date: Mon, 07 Feb 2022 11:50:10 GMT
+Content-Type: text/html
+Content-Length: 5262
+Connection: keep-alive
+Accept-Ranges: bytes
+Etag: "faa7cf06106ffa293981b64a49bfcf66317803d126c32aac720b367520e9c059303f9690f5a8b796cc740ec094e79d0a61d2cbac1273c5435eddd18c98b19d4e"
+Last-Modified: Mon, 07 Feb 2022 11:29:46 GMT
+Cache-Control: no-cache
+Vary: Accept-Encoding
+```
+
 # Streamlit reverse proxy issues
 
 ## Websocket won't connect through Nginx reverse proxy unless you use `localhost`, even over regular HTTP

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.9'
+version: "3.9"
 services:
   app:
     build: .
@@ -14,6 +14,7 @@ services:
     image: nginx:1.21.5-alpine
     volumes:
       - "$PWD/nginx.conf:/etc/nginx/conf.d/default.conf:ro"
+      - "$PWD/htpasswd:/etc/htpasswd:ro"
       - "$PWD/streamlit-demo.pem:/secrets/streamlit-demo.pem:ro"
       - "$PWD/streamlit-demo-key.pem:/secrets/streamlit-demo-key.pem:ro"
     ports:

--- a/htpasswd
+++ b/htpasswd
@@ -1,0 +1,6 @@
+# This file maps usernames to encrypted passwords. You can encrypt a password
+# using the `openssl passwd <unencrypted password>` command.
+#
+# See http://nginx.org/en/docs/http/ngx_http_auth_basic_module.html for more
+# informaation.
+demouser:wJmBCHpU7WREk

--- a/nginx.conf
+++ b/nginx.conf
@@ -5,6 +5,9 @@ server {
 
   # Simple reverse-proxying of regular HTTP traffic
   location / {
+    auth_basic "Top Secret Site";
+    auth_basic_user_file /etc/htpasswd;
+
     proxy_pass http://app:8501;
 
     # Reverse-proxying of websocket traffic.


### PR DESCRIPTION
This PR shows how to add basic password protection to your Streamlit app by implementing the "Basic HTTP Authentication" protocol in your Nginx reverse proxy server.

![2022-02-07 12 02 48 pm](https://user-images.githubusercontent.com/116432/152784697-f104b1d8-4418-40d7-bf2f-314c65f79218.gif)
